### PR TITLE
Fix: запретить неавторизованным смотреть тесты

### DIFF
--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class TestsController < ApplicationController
-  skip_before_action :authenticate_user!
-
   rescue_from ActiveRecord::RecordNotFound, with: :rescue_with_test_not_found
 
   def index


### PR DESCRIPTION
В модуле tests_controller.rb было skip_before_action :authenticate_user! Поэтому любой пользователь без авторизации мог зайти на страницу тестов и видеть их